### PR TITLE
[not ready] enable VTE's sixel support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,37 @@
-FROM ubuntu:20.04
+FROM ubuntu:21.04
 
 RUN apt-get update
 RUN apt-get install -y tzdata
-RUN apt-get install -y build-essential autoconf libgtk-3-dev libvte-2.91-dev liblua5.3-dev libpcre2-dev git xvfb
+RUN apt-get install -y \
+  autoconf \
+  build-essential \
+  cmake \
+  git \
+  libgirepository1.0-dev \
+  libglib2.0-dev \
+  libgnutls28-dev \
+  libgtk-3-dev \
+  liblua5.3-dev \
+  libpcre2-dev \
+  libsystemd-dev \
+  meson \
+  ninja-build \
+  valac \
+  xvfb
+
+RUN git clone https://gitlab.gnome.org/GNOME/vte.git \
+    && cd vte \
+    && meson . build -Dsixel=true \
+    && cd build \
+    && ninja \
+    && ninja install
 
 RUN mkdir -p /var/app
 ADD . /var/app
 WORKDIR /var/app
 
 RUN autoreconf -fvi
-RUN ./configure
+RUN PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ./configure
 RUN make
-RUN make check
-CMD xvfb-run -a ./src/tym -u ./lua/e2e.lua
+RUN LD_PRELOAD=/usr/local/lib/x86_64-linux-gnu/libvte-2.91.so make check
+CMD LD_PRELOAD=/usr/local/lib/x86_64-linux-gnu/libvte-2.91.so xvfb-run -a ./src/tym -u ./lua/e2e.lua

--- a/src/app.c
+++ b/src/app.c
@@ -249,6 +249,8 @@ void on_activate(GApplication* app, void* user_data)
   VteTerminal* vte = context->layout.vte;
   GtkWindow* window = context->layout.window;
 
+  vte_terminal_set_enable_sixel(context->layout.vte, true);
+
   GtkTargetEntry drop_types[] = {
     {"text/uri-list", 0, 0}
   };


### PR DESCRIPTION
VTE is recently [implementing libsixel API](https://gitlab.gnome.org/GNOME/vte/-/issues/253).
Although it's in the milestone for vte 0.68, whose release schedule hasn't fixed yet, the main functionality already works and I've tried to use it from tym.

Actually, the change in tym source code is just one line, but we need a custom-built libvte with its sixel support enabled. (<strike>CI build fails because of this</strike> fixed in the second commit)

```sh
git clone https://gitlab.gnome.org/GNOME/vte.git && cd vte
meson . build -Dsixel=true && cd build && ninja
sudo ninja install  # ususally this installes custom VTE under /usr/local/...
```

Then, build tym using the custom libvte.

```sh
cd /path/to/tym_repo
autoreconf -fvi
PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/ ./configure
make
LD_PRELOAD=/usr/local/lib/libvte-2.91.so ./src/tym
```

IMHO we can wait for the official VTE relase with the sixel support, but I submit this PR as a PoC impl.

![2022-01-02-135350_956x1059_scrot](https://user-images.githubusercontent.com/1460175/147867041-22553aff-bec6-4e68-834b-b6d80ee1b3ba.png)


solves #66