### PR TITLE
DBus IPC feature

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -6,6 +6,7 @@ noinst_HEADERS = \
 	config.h \
 	context.h \
 	hook.h \
+	ipc.h \
 	keymap.h \
 	meta.h \
 	option.h \

--- a/include/app.h
+++ b/include/app.h
@@ -11,9 +11,21 @@
 #define APP_H
 
 #include "common.h"
+#include "context.h"
+#include "ipc.h"
 
+typedef struct {
+  GApplication* gapp;
+  Meta* meta;
+  IPC* ipc;
+  GList* contexts;
+} App;
 
-int on_command_line(GApplication* app, GApplicationCommandLine* cli, void* user_data);
-void on_activate(GApplication* gapp, void* user_data);
+extern App* app;
+
+void app_init();
+void app_close();
+void app_quit_context(Context* context);
+int app_start(int argc, char **argv);
 
 #endif

--- a/include/app.h
+++ b/include/app.h
@@ -10,8 +10,8 @@
 #ifndef APP_H
 #define APP_H
 
-#include "common.h"
 #include "context.h"
+#include "meta.h"
 #include "ipc.h"
 
 typedef struct {

--- a/include/common.h.in
+++ b/include/common.h.in
@@ -30,13 +30,14 @@
 
 #ifdef DEBUG
 #define TYM_APP_ID "me.endaaman.tym_dev"
-#define TYM_OBJECT_PATH_FMT "/me/endaaman/tym_dev%d"
-#define TYM_OBJECT_PATH_FMT_STR "/me/endaaman/tym_dev%s"
+#define TYM_OBJECT_PATH_BASE "/me/endaaman/tym_dev"
 #else
 #define TYM_APP_ID "me.endaaman.tym"
-#define TYM_OBJECT_PATH_FMT "/me/endaaman/tym%d"
-#define TYM_OBJECT_PATH_FMT_STR "/me/endaaman/tym%s"
+#define TYM_OBJECT_PATH_BASE "/me/endaaman/tym"
 #endif
+
+#define TYM_OBJECT_PATH_FMT_INT TYM_OBJECT_PATH_BASE"%d"
+#define TYM_OBJECT_PATH_FMT_STR TYM_OBJECT_PATH_BASE"%s"
 
 #define TYM_ERROR_INVALID_METHOD_CALL 0
 

--- a/include/common.h.in
+++ b/include/common.h.in
@@ -30,9 +30,15 @@
 
 #ifdef DEBUG
 #define TYM_APP_ID "me.endaaman.tym_dev"
+#define TYM_OBJECT_PATH_FMT "/me/endaaman/tym_dev%d"
+#define TYM_OBJECT_PATH_FMT_STR "/me/endaaman/tym_dev%s"
 #else
 #define TYM_APP_ID "me.endaaman.tym"
+#define TYM_OBJECT_PATH_FMT "/me/endaaman/tym%d"
+#define TYM_OBJECT_PATH_FMT_STR "/me/endaaman/tym%s"
 #endif
+
+#define TYM_ERROR_INVALID_METHOD_CALL 0
 
 #define TYM_CONFIG_DIR_NAME "tym"
 #define TYM_CONFIG_FILE_NAME "config.lua"
@@ -61,10 +67,10 @@
 #define TYM_DEFAULT_CURSOR_BLINK_MODE TYM_CURSOR_BLINK_MODE_SYSTEM
 #define TYM_DEFAULT_CJK TYM_CJK_WIDTH_NARROW
 #define TYM_DEFAULT_URI_SCHEMES "http https file mailto"
-static const int TYM_DEFAULT_WIDTH = 80;
-static const int TYM_DEFAULT_HEIGHT = 22;
-static const int TYM_DEFAULT_SCALE = 100;
-static const int TYM_DEFAULT_SCROLLBACK = 512;
+extern const int TYM_DEFAULT_WIDTH;
+extern const int TYM_DEFAULT_HEIGHT;
+extern const int TYM_DEFAULT_SCALE;
+extern const int TYM_DEFAULT_SCROLLBACK;
 
 /* theme: iceberg (https://cocopon.github.io/iceberg.vim/) */
 #define TYM_DEFAULT_COLOR_0  "#161821"

--- a/include/context.h
+++ b/include/context.h
@@ -27,11 +27,17 @@ typedef struct {
 } Layout;
 
 typedef struct {
+  void* object;
+  int handler_id;
+} HandlerTag;
+
+typedef struct {
   int id; /* minus means the context is disposed */
   bool config_loading;
   bool initialized;
   char* object_path;
   int registration_id;
+  GList* handler_tags;
   Option* option;
   Config* config;
   Keymap* keymap;
@@ -42,10 +48,15 @@ typedef struct {
 } Context;
 
 
+
+#define context_signal_connect(context, instance, detailed_signal, c_handler) {\
+  context_add_handler_tag(context, instance, g_signal_connect(instance, detailed_signal, c_handler, context)); \
+}
+
 Context* context_init(int id, Option* option);
-void context_dispose_only(Context* context);
-bool context_is_disposed(Context* context);
+// void context_dispose_only(Context* context);
 void context_close(Context* context);
+void context_add_handler_tag(Context* context, void* object, int handler_id);
 void context_load_device(Context* context);
 void context_load_lua_context(Context* context);
 void context_log_message(Context* context, bool notify, const char* fmt, ...);

--- a/include/context.h
+++ b/include/context.h
@@ -18,11 +18,6 @@
 
 
 typedef struct {
-  bool config_loading;
-  bool initialized;
-} State;
-
-typedef struct {
   GtkWindow* window;
   VteTerminal* vte;
   GtkBox* hbox;
@@ -32,24 +27,30 @@ typedef struct {
 } Layout;
 
 typedef struct {
-  Meta* meta;
-  Option* option;
+  int id; /* minus means the context is disposed */
+  bool config_loading;
+  bool initialized;
+  char* object_path;
+  int registration_id;
+  Meta* meta; /* ref */
+  Option* option; /* ref */
   Config* config;
   Keymap* keymap;
   Hook* hook;
-  GApplication* app;
   GdkDevice* device;
   lua_State* lua;
   Layout layout;
-  State state;
 } Context;
 
 
-Context* context_init();
+Context* context_init(int id, Option* option);
+void context_dispose_only(Context* context);
+bool context_is_disposed(Context* context);
 void context_close(Context* context);
-int context_start(Context* context, int argc, char **argv);
 void context_load_device(Context* context);
 void context_load_lua_context(Context* context);
+void context_log_message(Context* context, bool notify, const char* fmt, ...);
+void context_log_warn(Context* context, bool notify, const char* fmt, ...);
 void context_restore_default(Context* context);
 void context_override_by_option(Context* context);
 char* context_acquire_config_path(Context* context);

--- a/include/context.h
+++ b/include/context.h
@@ -32,7 +32,7 @@ typedef struct {
 } HandlerTag;
 
 typedef struct {
-  int id; /* minus means the context is disposed */
+  int id;
   bool config_loading;
   bool initialized;
   char* object_path;

--- a/include/context.h
+++ b/include/context.h
@@ -32,8 +32,7 @@ typedef struct {
   bool initialized;
   char* object_path;
   int registration_id;
-  Meta* meta; /* ref */
-  Option* option; /* ref */
+  Option* option;
   Config* config;
   Keymap* keymap;
   Hook* hook;

--- a/include/hook.h
+++ b/include/hook.h
@@ -30,5 +30,6 @@ bool hook_perform_activated(Hook* hook, lua_State* L);
 bool hook_perform_deactivated(Hook* hook, lua_State* L);
 bool hook_perform_selected(Hook* hook, lua_State* L, const char* text);
 bool hook_perform_unselected(Hook* hook, lua_State* L);
+bool hook_perform_signal(Hook* hook, lua_State* L, const char* param);
 
 #endif

--- a/include/ipc.h
+++ b/include/ipc.h
@@ -1,0 +1,27 @@
+/**
+ * ipc.h
+ *
+ * Copyright (c) 2022 endaaman
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+#ifndef IPC_H
+#define IPC_H
+
+#include "context.h"
+
+typedef struct {
+  GHashTable* signals;
+  GHashTable* methods;
+} IPC;
+
+
+IPC* ipc_init();
+void ipc_close(IPC* ipc);
+bool ipc_signal_perform(IPC* ipc, Context* context, const char* signal_name, GVariant* parameters);
+bool ipc_method_perform(IPC* ipc, Context* context, const char* method_name, GVariant* parameters, GDBusMethodInvocation* invocation);
+
+
+#endif

--- a/include/meta.h
+++ b/include/meta.h
@@ -44,5 +44,6 @@ Meta* meta_init();
 void meta_close(Meta* meta);
 unsigned meta_size(Meta* meta);
 MetaEntry* meta_get_entry(Meta* meta, const char* key);
+GOptionEntry* meta_get_option_entries(Meta* meta);
 
 #endif

--- a/include/option.h
+++ b/include/option.h
@@ -14,27 +14,26 @@
 #include "meta.h"
 
 typedef struct {
-  GOptionEntry* entries;
-  bool version;
-  bool nolua;
-  char* config_path;
-  char* theme_path;
-  char* signal;
   GVariantDict* values;
 } Option;
 
 
-Option* option_init(Meta* meta);
+typedef struct{
+  bool version;
+  char* signal;
+} LocalOption;
+
+
+void* option_get(Option* option, const char* key);
+
+Option* option_init();
 void option_close(Option* option);
-void option_register_entries(Option* option, GApplication* app);
-void option_load_from_cli(Option* option, GApplicationCommandLine* cli);
-bool option_get_str_value(Option* option, const char* key, const char** value);
+void option_set_values(Option* option, GVariantDict* values);
+bool option_get_str_value(Option* option, const char* key, char** value);
 bool option_get_int_value(Option* option, const char* key, int* value);
 bool option_get_bool_value(Option* option, const char* key, bool* value);
-bool option_get_version(Option* option);
-char* option_get_config_path(Option* option);
-char* option_get_theme_path(Option* option);
-char* option_get_signal(Option* option);
-bool option_get_nolua(Option* option);
+char* option_get_str(Option* option, const char* key);
+int option_get_int(Option* option, const char* key);
+bool option_get_bool(Option* option, const char* key);
 
 #endif

--- a/include/tym.h
+++ b/include/tym.h
@@ -10,6 +10,6 @@
 #ifndef TYM_H
 #define TYM_H
 
-#include "context.h"
+#include "app.h"
 
 #endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -33,6 +33,7 @@ tym_SOURCES = \
 	config.c \
 	context.c \
 	hook.c \
+	ipc.c \
 	keymap.c \
 	meta.c \
 	option.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,6 +21,7 @@ COMMON_CFLAGS = \
 	-Wbad-function-cast \
 	-Wcast-align \
 	-Wredundant-decls \
+	-Wformat-security \
 	-Winline \
 	-I$(top_srcdir)/include
 

--- a/src/app.c
+++ b/src/app.c
@@ -389,7 +389,7 @@ int on_local_options(GApplication* gapp, GVariantDict* values, void* user_data)
 
   char* signal_name = NULL;
   char* method_name = NULL;
-  if (option_get_str_value(option, "send", &signal_name) || option_get_str_value(option, "call", &method_name)) {
+  if (option_get_str_value(option, "signal", &signal_name) || option_get_str_value(option, "call", &method_name)) {
     GDBusConnection* conn = g_application_get_dbus_connection(app->gapp);
     char* path = _get_dest_path_from_option(option);
     if (!path) {

--- a/src/app.c
+++ b/src/app.c
@@ -111,9 +111,8 @@ void app_quit_context(Context* context)
   g_application_release(app->gapp);
   GDBusConnection* conn = g_application_get_dbus_connection(app->gapp);
   g_dbus_connection_unregister_object(conn, context->registration_id);
-  context_dispose_only(context);
-
   context_log_message(context, false, "Quit.", context->id);
+  context_dispose_only(context);
   /* app->contexts = g_list_remove(app->contexts, context); */
 }
 

--- a/src/app.c
+++ b/src/app.c
@@ -394,6 +394,7 @@ int on_local_options(GApplication* gapp, GVariantDict* values, void* user_data)
     char* path = _get_dest_path_from_option(option);
     if (!path) {
       g_warning("--dest is not provided and $TYM_ID is not set.");
+      return 1;
     }
 
     char* param = NULL;

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -570,6 +570,18 @@ static int builtin_hex_to_rgb(lua_State* L)
   return 3;
 }
 
+static int builtin_signal(lua_State* L)
+{
+  /* TODO: impl */
+  return 0;
+}
+
+static int builtin_call(lua_State* L)
+{
+  /* TODO: impl */
+  return 0;
+}
+
 static int builtin_check_mod_state(lua_State* L)
 {
   const char* accelerator = luaL_checkstring(L, 1);
@@ -741,6 +753,8 @@ int builtin_register_module(lua_State* L)
     { "rgba_to_color"       , builtin_rgba_to_color        },
     { "rgb_to_hex"          , builtin_rgb_to_hex           },
     { "hex_to_rgb"          , builtin_hex_to_rgb           },
+    { "signal"              , builtin_signal               },
+    { "call"                , builtin_call                 },
     { "get_monitor_model"   , builtin_get_monitor_model    },
     { "get_cursor_position" , builtin_get_cursor_position  },
     { "get_clipboard"       , builtin_get_clipboard        },

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -18,7 +18,7 @@ static int builtin_get(lua_State* L)
   Context* context = (Context*)lua_touserdata(L, lua_upvalueindex(1));
 
   const char* key = luaL_checkstring(L, 1);
-  MetaEntry* e = meta_get_entry(context->meta, key);
+  MetaEntry* e = meta_get_entry(app->meta, key);
   if (!e) {
     luaX_warn(L, "Invalid config key: '%s'", key);
     lua_pushnil(L);
@@ -58,7 +58,7 @@ static int builtin_set(lua_State* L)
 
   const char* key = luaL_checkstring(L, 1);
 
-  MetaEntry* e = meta_get_entry(context->meta, key);
+  MetaEntry* e = meta_get_entry(app->meta, key);
   if (!e) {
     luaX_warn(L, "Invalid config key: '%s'", key);
     return 0;
@@ -97,10 +97,10 @@ static int builtin_set(lua_State* L)
 
 static int get_default_value(lua_State* L)
 {
-  Context* context = (Context*)lua_touserdata(L, lua_upvalueindex(1));
+  /* Context* context = (Context*)lua_touserdata(L, lua_upvalueindex(1)); */
 
   const char* key = luaL_checkstring(L, 1);
-  MetaEntry* e = meta_get_entry(context->meta, key);
+  MetaEntry* e = meta_get_entry(app->meta, key);
   if (!e) {
     luaX_warn(L, "Invalid config key: '%s'", key);
     lua_pushnil(L);
@@ -130,7 +130,7 @@ static int builtin_get_config(lua_State* L)
 
   lua_newtable(L);
 
-  for (GList* li = context->meta->list; li != NULL; li = li->next) {
+  for (GList* li = app->meta->list; li != NULL; li = li->next) {
     MetaEntry* e = (MetaEntry*)li->data;
     char* key = e->name;
     lua_pushstring(L, key);
@@ -165,7 +165,7 @@ static int builtin_set_config(lua_State* L)
   while (lua_next(L, -2)) {
     lua_pushvalue(L, -2);
     const char* key = lua_tostring(L, -1);
-    MetaEntry* e = meta_get_entry(context->meta, key);
+    MetaEntry* e = meta_get_entry(app->meta, key);
     if (e) {
       int type = lua_type(L, -2);
       switch (e->type) {

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -42,13 +42,10 @@ static int builtin_get(lua_State* L)
   return 1;
 }
 
-
 static int builtin_quit(lua_State* L)
 {
   Context* context = (Context*)lua_touserdata(L, lua_upvalueindex(1));
-  /* TODO: impl */
-  /* g_application_quit(G_APPLICATION(context->app)); */
-  app_quit_context(context);
+  gtk_window_close(context->layout.window);
   return 0;
 }
 

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -767,7 +767,20 @@ static int builtin_get_theme_path(lua_State* L)
 static int builtin_get_id(lua_State* L)
 {
   Context* context = (Context*)lua_touserdata(L, lua_upvalueindex(1));
-  lua_pushnumber(L, context->id);
+  lua_pushinteger(L, context->id);
+  return 1;
+}
+
+static int builtin_get_ids(lua_State* L)
+{
+  lua_newtable(L);
+  int i = 0;
+  for (GList* li = app->contexts; li != NULL; li = li->next) {
+    Context* c = (Context*)li->data;
+    lua_pushinteger(L, c->id);
+    lua_rawseti(L, -2, i + 1);
+    i += 1;
+  }
   return 1;
 }
 
@@ -842,6 +855,7 @@ int builtin_register_module(lua_State* L)
     { "get_config_path"     , builtin_get_config_path      },
     { "get_theme_path"      , builtin_get_theme_path       },
     { "get_id"              , builtin_get_id               },
+    { "get_ids"             , builtin_get_ids              },
     { "get_object_path"     , builtin_get_object_path      },
     { "get_pid"             , builtin_get_pid              },
     { "get_version"         , builtin_get_version          },

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -10,6 +10,7 @@
 #include "builtin.h"
 #include "context.h"
 #include "command.h"
+#include "app.h"
 
 
 static int builtin_get(lua_State* L)
@@ -45,7 +46,9 @@ static int builtin_get(lua_State* L)
 static int builtin_quit(lua_State* L)
 {
   Context* context = (Context*)lua_touserdata(L, lua_upvalueindex(1));
-  g_application_quit(G_APPLICATION(context->app));
+  /* TODO: impl */
+  /* g_application_quit(G_APPLICATION(context->app)); */
+  app_quit_context(context);
   return 0;
 }
 
@@ -673,15 +676,29 @@ static int builtin_get_theme_path(lua_State* L)
   return 1;
 }
 
-static int builtin_get_version(lua_State* L)
+static int builtin_get_id(lua_State* L)
 {
-  lua_pushstring(L, PACKAGE_VERSION);
+  Context* context = (Context*)lua_touserdata(L, lua_upvalueindex(1));
+  lua_pushnumber(L, context->id);
+  return 1;
+}
+
+static int builtin_get_object_path(lua_State* L)
+{
+  Context* context = (Context*)lua_touserdata(L, lua_upvalueindex(1));
+  lua_pushstring(L, context->object_path);
   return 1;
 }
 
 static int builtin_get_pid(lua_State* L)
 {
   lua_pushinteger(L, getpid());
+  return 1;
+}
+
+static int builtin_get_version(lua_State* L)
+{
+  lua_pushstring(L, PACKAGE_VERSION);
   return 1;
 }
 
@@ -734,6 +751,8 @@ int builtin_register_module(lua_State* L)
     { "get_text"            , builtin_get_text             },
     { "get_config_path"     , builtin_get_config_path      },
     { "get_theme_path"      , builtin_get_theme_path       },
+    { "get_id"              , builtin_get_id               },
+    { "get_object_path"     , builtin_get_object_path      },
     { "get_pid"             , builtin_get_pid              },
     { "get_version"         , builtin_get_version          },
     // DEPRECATED

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -365,11 +365,11 @@ static int builtin_send_key(lua_State* L)
 typedef struct {
   Context* context;
   int ref;
-} TimeoutNotation;
+} TimeoutCallbackNotation;
 
 static int timeout_callback(void* user_data)
 {
-  TimeoutNotation* notation = (TimeoutNotation*) user_data;
+  TimeoutCallbackNotation* notation = (TimeoutCallbackNotation*)user_data;
 
   lua_State* L = notation->context->lua;
   lua_rawgeti(L, LUA_REGISTRYINDEX, notation->ref);
@@ -398,7 +398,7 @@ static int builtin_set_timeout(lua_State* L)
 
   lua_pushvalue(L, 1);
   int ref = luaL_ref(L, LUA_REGISTRYINDEX);
-  TimeoutNotation* notation = g_malloc0(sizeof(TimeoutNotation));
+  TimeoutCallbackNotation* notation = g_malloc0(sizeof(TimeoutCallbackNotation));
   notation->context = context;
   notation->ref = ref;
   int tag = g_timeout_add_full(G_PRIORITY_DEFAULT, interval, (GSourceFunc)timeout_callback, notation, g_free);
@@ -573,23 +573,23 @@ static int builtin_hex_to_rgb(lua_State* L)
 static GVariant* table_to_variant(lua_State* L, int table_index)
 {
   luaL_argcheck(L, lua_istable(L, table_index), table_index, "table expected");
-  size_t param_len = lua_rawlen(L, table_index);
-  GVariant** vv = g_malloc0_n(param_len, sizeof(char*));
+  size_t num_params = lua_rawlen(L, table_index);
+  GVariant** vv = g_malloc0_n(num_params, sizeof(char*));
   int i = 0;
-  while (i < param_len) {
+  while (i < num_params) {
     lua_rawgeti(L, table_index, i + 1); // args[table_index][i+1]
     vv[i] = g_variant_new_string(lua_tostring(L, -1));
     lua_pop(L, 1);
     i += 1;
   }
-  GVariant* p = g_variant_new_tuple(vv, param_len);
+  GVariant* p = g_variant_new_tuple(vv, num_params);
   g_free(vv);
   return p;
 }
 
+/* usage tym.signal(0, 'hook', {'param'}) */
 static int builtin_signal(lua_State* L)
 {
-  /* usage tym.signal(0, 'hook', {'param'}) */
   int target_id = luaL_checkinteger(L, 1);
   const char* signal_name = luaL_checkstring(L, 2);
   GVariant* params = lua_gettop(L) >= 3
@@ -610,20 +610,103 @@ static int builtin_signal(lua_State* L)
   return 0;
 }
 
-static int builtin_call(lua_State* L)
+typedef struct {
+  Context* context;
+  int ref;
+} CallCallbackNotation;
+
+void push_value_by_gvariant(lua_State* L, GVariant* v) {
+  if (g_variant_is_of_type(v, G_VARIANT_TYPE_INT32)) {
+    lua_pushinteger(L, g_variant_get_int32(v));
+  } else if (g_variant_is_of_type(v, G_VARIANT_TYPE_STRING)) {
+    char* s = NULL;
+    g_variant_get(v, "s", &s);
+    lua_pushstring(L, s);
+    g_free(s);
+  } else if (g_variant_is_of_type(v, G_VARIANT_TYPE_ARRAY) || g_variant_is_of_type(v, G_VARIANT_TYPE_TUPLE)) {
+    lua_newtable(L);
+    size_t num = g_variant_n_children(v);
+    int i = 0;
+    while (i < num) {
+      GVariant* e = g_variant_get_child_value(v, i);
+      push_value_by_gvariant(L, e);
+      lua_rawseti(L, -2, i + 1);
+      i += 1;
+    }
+  } else {
+    lua_pushstring(L, g_variant_print(v, false));
+  }
+}
+
+void call_callback(GObject* source_object, GAsyncResult* res, void* user_data)
 {
-  /* usage tym.call(0, 'exec', {'param'}) */
-  int target_id = luaL_checkinteger(L, 1);
-  const char* method_name = luaL_checkstring(L, 2);
-  GVariant* params = lua_gettop(L) >= 3
-    ? table_to_variant(L, 3)
-    : g_variant_new("()");
+  GError* error = NULL;
+  TimeoutCallbackNotation* notation = (TimeoutCallbackNotation*)user_data;
+  Context* context = notation->context;
+  lua_State* L = context->lua;
 
   GDBusConnection* conn = g_application_get_dbus_connection(app->gapp);
-  GError* error = NULL;
+  GVariant* result = g_dbus_connection_call_finish(conn, res, &error);
+
+  lua_rawgeti(L, LUA_REGISTRYINDEX, notation->ref);
+  if (!lua_isfunction(L, -1)) {
+    lua_pop(L, 1); // pop none-function
+    context_log_warn(context, true, "tried to call non-function");
+    return;
+  }
+
+  int num_args = 0;
+  if (error) {
+    char* m = g_strdup_printf("DBus error: '%s'", error->message);
+    luaX_warn(L, "%s", m);
+    lua_pushstring(L, m);
+    g_error_free(error);
+    g_free(m);
+    num_args = 1;
+  } else {
+    dd("DBus method call result: `%s`", g_variant_print(result, true));
+    int num_result = g_variant_n_children(result);
+    int i = 0;
+    while (i < num_result) {
+      GVariant* e = g_variant_get_child_value(result, i);
+      push_value_by_gvariant(L, e);
+      i += 1;
+    }
+    num_args = num_result;
+  }
+
+  if (lua_pcall(L, num_args, 0, 0) != LUA_OK) {
+    luaX_warn(L, "Error in timeout function: '%s'", lua_tostring(L, -1));
+    lua_pop(L, 1); // error
+  }
+}
+
+/* usage: tym.call(0, 'eval', {'return 1+2'}, function(...) end) */
+static int builtin_call(lua_State* L)
+{
+  Context* context = (Context*)lua_touserdata(L, lua_upvalueindex(1));
+  int target_id = luaL_checkinteger(L, 1);
+  const char* method_name = luaL_checkstring(L, 2);
+  GVariant* params = table_to_variant(L, 3);
+
+  bool has_cb = lua_gettop(L) >= 4;
+
+  CallCallbackNotation* notation = NULL;
+  GAsyncReadyCallback cb = NULL;
+  if (has_cb) {
+    luaL_argcheck(L, lua_isfunction(L, 4), 4, "function expected");
+    lua_pushvalue(L, 4);
+    int ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    notation = (CallCallbackNotation*)g_malloc(sizeof(CallCallbackNotation*));
+    notation->context = context;
+    notation->ref = ref;
+    cb = (GAsyncReadyCallback)call_callback;
+  }
+
+  GDBusConnection* conn = g_application_get_dbus_connection(app->gapp);
   char* object_path = g_strdup_printf(TYM_OBJECT_PATH_FMT_INT, target_id);
-  /* TODO: make this async */
-  GVariant* result = g_dbus_connection_call_sync(
+
+  g_dbus_connection_call(
       conn,        // conn
       TYM_APP_ID,  // bus_name
       object_path, // object_path
@@ -632,33 +715,13 @@ static int builtin_call(lua_State* L)
       params,      // parameters
       NULL,        // reply_type
       G_DBUS_CALL_FLAGS_NONE, // flags
-      10000,        // timeout
+      1000,        // timeout
       NULL,        // cancellable
-      &error
+      cb,          // callback
+      notation     // user_data
   );
   g_free(object_path);
-  if (error) {
-    luaX_warn(L, "DBus error: '%s'", error->message);
-    g_error_free(error);
-    return 0;
-  }
-
-  size_t result_len = g_variant_n_children(result);
-  int i = 0;
-  dd("result type %s", g_variant_get_type_string(result));
-  while (i < result_len) {
-    GVariant* v = g_variant_get_child_value(result, i);
-    if (g_variant_is_of_type(v, G_VARIANT_TYPE_INT32)) {
-      lua_pushinteger(L, g_variant_get_int32(v));
-    } else if (g_variant_is_of_type(v, G_VARIANT_TYPE_INT32)) {
-      lua_pushstring(L, g_variant_get_bytestring(v));
-    } else {
-      lua_pushstring(L, g_variant_print(v, true));
-    }
-    i += 1;
-  }
-
-  return result_len;
+  return 0;
 }
 
 static int builtin_check_mod_state(lua_State* L)

--- a/src/common.c
+++ b/src/common.c
@@ -9,6 +9,11 @@
 
 #include "common.h"
 
+const int TYM_DEFAULT_WIDTH = 80;
+const int TYM_DEFAULT_HEIGHT = 22;
+const int TYM_DEFAULT_SCALE = 100;
+const int TYM_DEFAULT_SCROLLBACK = 512;
+
 
 #ifdef DEBUG
 void debug_dump_stack(lua_State* L, char* file, unsigned line)
@@ -106,7 +111,7 @@ int luaX_warn(lua_State* L, const char* fmt, ...)
   lua_pushvfstring(L, fmt, argp);
   va_end(argp);
   lua_concat(L, 2);
-  g_message("%s",lua_tostring(L,-1));
+  g_message("%s", lua_tostring(L,-1));
   lua_pop(L, 1);
   return 0;
 }

--- a/src/context.c
+++ b/src/context.c
@@ -93,7 +93,6 @@ Context* context_init(int id, Option* option)
   Context* context = g_malloc0(sizeof(Context));
   g_assert(id >= 0);
   context->id = id;
-  context->meta = app->meta;
   context->option = option;
   context->config_loading = false;
   context->initialized = false;
@@ -183,8 +182,8 @@ void context_log_warn(Context* context, bool notify, const char* fmt, ...)
 
 void context_restore_default(Context* context)
 {
-  config_restore_default(context->config, context->meta);
-  for (GList* li = context->meta->list; li != NULL; li = li->next) {
+  config_restore_default(context->config, app->meta);
+  for (GList* li = app->meta->list; li != NULL; li = li->next) {
     MetaEntry* e = (MetaEntry*)li->data;
     char* target = NULL;
     if (strncmp("color_", e->name, 6) == 0) {
@@ -218,7 +217,7 @@ void context_restore_default(Context* context)
   while (i < 16) {
     char s[10] = {};
     g_snprintf(s, 10, "color_%d", i);
-    MetaEntry* e = meta_get_entry(context->meta, s);
+    MetaEntry* e = meta_get_entry(app->meta, s);
     assert(gdk_rgba_parse(&palette[i], e->default_value));
     i += 1;
   }
@@ -227,7 +226,7 @@ void context_restore_default(Context* context)
 
 void context_override_by_option(Context* context)
 {
-  for (GList* li = context->meta->list; li != NULL; li = li->next) {
+  for (GList* li = app->meta->list; li != NULL; li = li->next) {
     MetaEntry* e = (MetaEntry*)li->data;
     char* key = e->name;
     switch (e->type) {
@@ -341,7 +340,7 @@ void context_load_theme(Context* context)
     goto EXIT;
   }
 
-  for (GList* li = context->meta->list; li != NULL; li = li->next) {
+  for (GList* li = app->meta->list; li != NULL; li = li->next) {
     MetaEntry* e = (MetaEntry*)li->data;
     if (!e->is_theme) {
       continue;
@@ -475,7 +474,7 @@ GdkWindow* context_get_gdk_window(Context* context)
 
 const char* context_get_str(Context* context, const char* key)
 {
-  MetaEntry* e = meta_get_entry(context->meta, key);
+  MetaEntry* e = meta_get_entry(app->meta, key);
   if (e->getter) {
     return ((PropertyStrGetter)e->getter)(context, key);
   }
@@ -484,7 +483,7 @@ const char* context_get_str(Context* context, const char* key)
 
 int context_get_int(Context* context, const char* key)
 {
-  MetaEntry* e = meta_get_entry(context->meta, key);
+  MetaEntry* e = meta_get_entry(app->meta, key);
   if (e->getter) {
     return ((PropertyIntGetter)e->getter)(context, key);
   }
@@ -493,7 +492,7 @@ int context_get_int(Context* context, const char* key)
 
 bool context_get_bool(Context* context, const char* key)
 {
-  MetaEntry* e = meta_get_entry(context->meta, key);
+  MetaEntry* e = meta_get_entry(app->meta, key);
   if (e->getter) {
     return ((PropertyBoolGetter)e->getter)(context, key);
   }
@@ -502,7 +501,7 @@ bool context_get_bool(Context* context, const char* key)
 
 void context_set_str(Context* context, const char* key, const char* value)
 {
-  MetaEntry* e = meta_get_entry(context->meta, key);
+  MetaEntry* e = meta_get_entry(app->meta, key);
   if (e->setter) {
     ((PropertyStrSetter)e->setter)(context, key, value);
     return;
@@ -516,7 +515,7 @@ void context_set_str(Context* context, const char* key, const char* value)
 
 void context_set_int(Context* context, const char* key, int value)
 {
-  MetaEntry* e = meta_get_entry(context->meta, key);
+  MetaEntry* e = meta_get_entry(app->meta, key);
   if (e->setter) {
     ((PropertyIntSetter)e->setter)(context, key, value);
     return;
@@ -530,7 +529,7 @@ void context_set_int(Context* context, const char* key, int value)
 
 void context_set_bool(Context* context, const char* key, bool value)
 {
-  MetaEntry* e = meta_get_entry(context->meta, key);
+  MetaEntry* e = meta_get_entry(app->meta, key);
   if (e->setter) {
     ((PropertyBoolSetter)e->setter)(context, key, value);
     return;

--- a/src/hook.c
+++ b/src/hook.c
@@ -19,6 +19,7 @@
 #define HOOK_KEY_DEACTIVATED "deactivated"
 #define HOOK_KEY_SELECTED "selected"
 #define HOOK_KEY_UNSELECTED "unselected"
+#define HOOK_KEY_SIGNAL "signal"
 
 
 const char* HOOK_KEYS[] = {
@@ -31,6 +32,7 @@ const char* HOOK_KEYS[] = {
   HOOK_KEY_DEACTIVATED,
   HOOK_KEY_SELECTED,
   HOOK_KEY_UNSELECTED,
+  HOOK_KEY_SIGNAL,
   NULL
 };
 
@@ -84,7 +86,7 @@ bool hook_set_ref(Hook* hook, const char* key, int ref, int* old_ref)
   }
   g_hash_table_remove(hook->refs, old_key);
   g_hash_table_insert(hook->refs, g_strdup(key), memdup(&ref, sizeof(int)));
-  dd("hook (%s) is registered. ref: %d", key, ref);
+  dd("hook '%s' is registered. ref: %d", key, ref);
   return true;
 }
 
@@ -221,4 +223,13 @@ bool hook_perform_unselected(Hook* hook, lua_State* L)
     return false;
   }
   return hook_perform(hook, L, HOOK_KEY_UNSELECTED, 0, 0);
+}
+
+bool hook_perform_signal(Hook* hook, lua_State* L, const char* param)
+{
+  if (!L) {
+    return false;
+  }
+  lua_pushstring(L, param);
+  return hook_perform(hook, L, HOOK_KEY_SIGNAL, 1, 0);
 }

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -1,0 +1,186 @@
+/**
+ * ipc.c
+ *
+ * Copyright (c) 2022 endaaman
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+
+#include "ipc.h"
+#include "app.h"
+
+
+typedef void (*TymSignalHandler)(Context*, GVariant*);
+typedef void (*TymMethodHandler)(Context*, GVariant*, GDBusMethodInvocation*);
+
+typedef struct {
+  const char* signal_name;
+  TymSignalHandler func;
+} SignalDef;
+
+typedef struct {
+  const char* method_name;
+  TymMethodHandler func;
+} MethodDef;
+
+
+void ipc_signal_hook(Context* context, GVariant* parameters)
+{
+  df();
+  const char* param = NULL;
+  size_t size = g_variant_n_children(parameters);
+  if (size > 0) {
+    g_variant_get_child(parameters, 0, "s", &param);
+  }
+  hook_perform_signal(context->hook, context->lua, param);
+}
+
+SignalDef signals[] = {
+  { "hook", ipc_signal_hook, },
+  { NULL, NULL, }
+};
+
+void ipc_method_get_ids(Context* context, GVariant* parameters, GDBusMethodInvocation* invocation)
+{
+  GVariantBuilder *builder = g_variant_builder_new(G_VARIANT_TYPE_ARRAY);
+  for (GList* li = app->contexts; li != NULL; li = li->next) {
+    Context* c = (Context*)li->data;
+    if (c->id < 0) {
+      continue;
+    }
+    g_variant_builder_add(builder, "i", c->id);
+  }
+  GVariant* v = g_variant_builder_end(builder);
+  v = g_variant_new_tuple(&v, 1);
+  g_dbus_method_invocation_return_value(invocation, v);
+}
+
+void ipc_method_echo(Context* context, GVariant* parameters, GDBusMethodInvocation* invocation)
+{
+  g_dbus_method_invocation_return_value(invocation, parameters);
+}
+
+static void ipc_do_lua(Context* context, GVariant* parameters, GDBusMethodInvocation* invocation, bool needs_result, bool is_file)
+{
+  lua_State* L = context->lua;
+  char* param = NULL;
+  g_variant_get_child(parameters, 0, "s", &param);
+
+  char* result = NULL;
+
+  int suc = is_file ? luaL_dofile(L, param) : luaL_dostring(L, param);
+
+  if (suc != 0) {
+    result = g_strdup(lua_tostring(L, -1));
+    context_log_warn(context, true, result);
+    lua_pop(L, -1);
+  } else {
+    if (needs_result) {
+      int top = lua_gettop(L);
+      if (top == 1) {
+        result = g_strdup(lua_tostring(L, -1));
+      } else {
+        result = g_strdup_printf("Stack top is not 1(top = %d)", top);
+      }
+      lua_settop(L, 0);
+    }
+  }
+
+  GVariant* v = needs_result ? g_variant_new("(s)", result) : g_variant_new("()");
+  g_free(result);
+  g_dbus_method_invocation_return_value(invocation, v);
+}
+
+void ipc_method_eval(Context* context, GVariant* parameters, GDBusMethodInvocation* invocation)
+{
+  ipc_do_lua(context, parameters, invocation, true, false);
+}
+
+void ipc_method_eval_file(Context* context, GVariant* parameters, GDBusMethodInvocation* invocation)
+{
+  ipc_do_lua(context, parameters, invocation, true, true);
+}
+
+void ipc_method_exec(Context* context, GVariant* parameters, GDBusMethodInvocation* invocation)
+{
+  ipc_do_lua(context, parameters, invocation, false, false);
+}
+
+void ipc_method_exec_file(Context* context, GVariant* parameters, GDBusMethodInvocation* invocation)
+{
+  ipc_do_lua(context, parameters, invocation, false, true);
+}
+
+MethodDef methods[] = {
+  { "echo",      ipc_method_echo, },
+  { "get_ids",   ipc_method_get_ids, },
+  { "eval",      ipc_method_eval, },
+  { "eval_file", ipc_method_eval_file, },
+  { "exec",      ipc_method_exec, },
+  { "exec_file", ipc_method_exec_file, },
+  { NULL, NULL, }
+};
+
+IPC* ipc_init()
+{
+  IPC* ipc = g_malloc0(sizeof(IPC));
+  ipc->signals = g_hash_table_new_full(
+    g_str_hash,
+    g_str_equal,
+    NULL,
+    NULL
+  );
+
+  ipc->methods = g_hash_table_new_full(
+    g_str_hash,
+    g_str_equal,
+    NULL,
+    NULL
+  );
+
+  int i = 0;
+  while (signals[i].signal_name) {
+    SignalDef* d = &signals[i];
+    g_hash_table_insert(ipc->signals, (void*)d->signal_name, d);
+    i += 1;
+  }
+
+  i = 0;
+  while (methods[i].method_name) {
+    MethodDef* d = &methods[i];
+    g_hash_table_insert(ipc->methods, (void*)d->method_name, d);
+    i += 1;
+  }
+  return ipc;
+}
+
+void ipc_close(IPC* ipc)
+{
+  g_hash_table_destroy(ipc->signals);
+  g_hash_table_destroy(ipc->methods);
+  g_free(ipc);
+}
+
+bool ipc_signal_perform(IPC* ipc, Context* context, const char* signal_name, GVariant* parameters)
+{
+  SignalDef* d = g_hash_table_lookup(ipc->signals, signal_name);
+  if (!d) {
+    dd("invalid signal_name: '%s'", signal_name);
+    return false;
+  }
+  d->func(context, parameters);
+  return true;
+}
+
+bool ipc_method_perform(IPC* ipc, Context* context, const char* method_name, GVariant* parameters, GDBusMethodInvocation* invocation)
+{
+  MethodDef* d = g_hash_table_lookup(ipc->methods, method_name);
+  if (!d) {
+    dd("invalid method_name: '%s'", method_name);
+    return false;
+  }
+  d->func(context, parameters, invocation);
+  return true;
+}

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -47,9 +47,6 @@ void ipc_method_get_ids(Context* context, GVariant* parameters, GDBusMethodInvoc
   GVariantBuilder *builder = g_variant_builder_new(G_VARIANT_TYPE_ARRAY);
   for (GList* li = app->contexts; li != NULL; li = li->next) {
     Context* c = (Context*)li->data;
-    if (c->id < 0) {
-      continue;
-    }
     g_variant_builder_add(builder, "i", c->id);
   }
   GVariant* v = g_variant_builder_end(builder);

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -75,14 +75,15 @@ static void ipc_do_lua(Context* context, GVariant* parameters, GDBusMethodInvoca
   if (suc != 0) {
     result = g_strdup(lua_tostring(L, -1));
     context_log_warn(context, true, result);
-    lua_pop(L, -1);
+    lua_settop(L, 0);
   } else {
     if (needs_result) {
       int top = lua_gettop(L);
-      if (top == 1) {
+      if (top > 0) {
         result = g_strdup(lua_tostring(L, -1));
       } else {
-        result = g_strdup_printf("Stack top is not 1(top = %d)", top);
+        result = g_strdup_printf("Lua stack is empty. `return` is needed.");
+        context_log_warn(context, true, result);
       }
       lua_settop(L, 0);
     }

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -26,13 +26,13 @@ typedef struct {
 } MethodDef;
 
 
-void ipc_signal_hook(Context* context, GVariant* parameters)
+void ipc_signal_hook(Context* context, GVariant* params)
 {
   df();
   const char* param = NULL;
-  size_t size = g_variant_n_children(parameters);
+  size_t size = g_variant_n_children(params);
   if (size > 0) {
-    g_variant_get_child(parameters, 0, "s", &param);
+    g_variant_get_child(params, 0, "s", &param);
   }
   hook_perform_signal(context->hook, context->lua, param);
 }
@@ -42,7 +42,7 @@ SignalDef signals[] = {
   { NULL, NULL, }
 };
 
-void ipc_method_get_ids(Context* context, GVariant* parameters, GDBusMethodInvocation* invocation)
+void ipc_method_get_ids(Context* context, GVariant* params, GDBusMethodInvocation* invocation)
 {
   GVariantBuilder *builder = g_variant_builder_new(G_VARIANT_TYPE_ARRAY);
   for (GList* li = app->contexts; li != NULL; li = li->next) {
@@ -54,16 +54,16 @@ void ipc_method_get_ids(Context* context, GVariant* parameters, GDBusMethodInvoc
   g_dbus_method_invocation_return_value(invocation, v);
 }
 
-void ipc_method_echo(Context* context, GVariant* parameters, GDBusMethodInvocation* invocation)
+void ipc_method_echo(Context* context, GVariant* params, GDBusMethodInvocation* invocation)
 {
-  g_dbus_method_invocation_return_value(invocation, parameters);
+  g_dbus_method_invocation_return_value(invocation, params);
 }
 
-static void ipc_do_lua(Context* context, GVariant* parameters, GDBusMethodInvocation* invocation, bool needs_result, bool is_file)
+static void ipc_do_lua(Context* context, GVariant* params, GDBusMethodInvocation* invocation, bool needs_result, bool is_file)
 {
   lua_State* L = context->lua;
   char* param = NULL;
-  g_variant_get_child(parameters, 0, "s", &param);
+  g_variant_get_child(params, 0, "s", &param);
 
   char* result = NULL;
 
@@ -91,24 +91,24 @@ static void ipc_do_lua(Context* context, GVariant* parameters, GDBusMethodInvoca
   g_dbus_method_invocation_return_value(invocation, v);
 }
 
-void ipc_method_eval(Context* context, GVariant* parameters, GDBusMethodInvocation* invocation)
+void ipc_method_eval(Context* context, GVariant* params, GDBusMethodInvocation* invocation)
 {
-  ipc_do_lua(context, parameters, invocation, true, false);
+  ipc_do_lua(context, params, invocation, true, false);
 }
 
-void ipc_method_eval_file(Context* context, GVariant* parameters, GDBusMethodInvocation* invocation)
+void ipc_method_eval_file(Context* context, GVariant* params, GDBusMethodInvocation* invocation)
 {
-  ipc_do_lua(context, parameters, invocation, true, true);
+  ipc_do_lua(context, params, invocation, true, true);
 }
 
-void ipc_method_exec(Context* context, GVariant* parameters, GDBusMethodInvocation* invocation)
+void ipc_method_exec(Context* context, GVariant* params, GDBusMethodInvocation* invocation)
 {
-  ipc_do_lua(context, parameters, invocation, false, false);
+  ipc_do_lua(context, params, invocation, false, false);
 }
 
-void ipc_method_exec_file(Context* context, GVariant* parameters, GDBusMethodInvocation* invocation)
+void ipc_method_exec_file(Context* context, GVariant* params, GDBusMethodInvocation* invocation)
 {
-  ipc_do_lua(context, parameters, invocation, false, true);
+  ipc_do_lua(context, params, invocation, false, true);
 }
 
 MethodDef methods[] = {
@@ -161,24 +161,24 @@ void ipc_close(IPC* ipc)
   g_free(ipc);
 }
 
-bool ipc_signal_perform(IPC* ipc, Context* context, const char* signal_name, GVariant* parameters)
+bool ipc_signal_perform(IPC* ipc, Context* context, const char* signal_name, GVariant* params)
 {
   SignalDef* d = g_hash_table_lookup(ipc->signals, signal_name);
   if (!d) {
     dd("invalid signal_name: '%s'", signal_name);
     return false;
   }
-  d->func(context, parameters);
+  d->func(context, params);
   return true;
 }
 
-bool ipc_method_perform(IPC* ipc, Context* context, const char* method_name, GVariant* parameters, GDBusMethodInvocation* invocation)
+bool ipc_method_perform(IPC* ipc, Context* context, const char* method_name, GVariant* params, GDBusMethodInvocation* invocation)
 {
   MethodDef* d = g_hash_table_lookup(ipc->methods, method_name);
   if (!d) {
     dd("invalid method_name: '%s'", method_name);
     return false;
   }
-  d->func(context, parameters, invocation);
+  d->func(context, params, invocation);
   return true;
 }

--- a/src/meta.c
+++ b/src/meta.c
@@ -222,3 +222,105 @@ MetaEntry* meta_get_entry(Meta* meta, const char* key)
   }
   return NULL;
 }
+
+GOptionEntry* meta_get_option_entries(Meta* meta)
+{
+  GOptionEntry app_options[] = {
+    {
+      .long_name = "version",
+      .short_name = 'v',
+      .flags = G_OPTION_FLAG_NONE,
+      .arg = G_OPTION_ARG_NONE,
+      .arg_data = NULL,
+      .description = "Show version",
+      .arg_description = NULL,
+    }, {
+      .long_name = "use",
+      .short_name = 'u',
+      .flags = G_OPTION_FLAG_NONE,
+      .arg = G_OPTION_ARG_STRING,
+      .arg_data = NULL,
+      .description = "<path> to config file. Set '" TYM_SYMBOL_NONE "' to start without loading config",
+      .arg_description = "<path>",
+    }, {
+      .long_name = "theme",
+      .short_name = 't',
+      .flags = G_OPTION_FLAG_NONE,
+      .arg = G_OPTION_ARG_STRING,
+      .arg_data = NULL,
+      .description = "<path> to theme file. Set '" TYM_SYMBOL_NONE "' to start without loading theme",
+      .arg_description = "<path>",
+    }, {
+      .long_name = "id",
+      .short_name = 'i',
+      .flags = G_OPTION_FLAG_NONE,
+      .arg = G_OPTION_ARG_INT,
+      .arg_data = NULL,
+      .description = "<id> to use in the new instance",
+      .arg_description = "<id>",
+    }, {
+      .long_name = "send",
+      .short_name = 's',
+      .flags = G_OPTION_FLAG_NONE,
+      .arg = G_OPTION_ARG_STRING,
+      .arg_data = NULL,
+      .description = "<signal name> to send via DBus",
+      .arg_description = "<signal name>",
+    }, {
+      .long_name = "call",
+      .short_name = 'c',
+      .flags = G_OPTION_FLAG_NONE,
+      .arg = G_OPTION_ARG_STRING,
+      .arg_data = NULL,
+      .description = "<method name> to call via DBus",
+      .arg_description = "<method name>",
+    }, {
+      .long_name = "param",
+      .short_name = 'p',
+      .flags = G_OPTION_FLAG_NONE,
+      .arg = G_OPTION_ARG_STRING,
+      .arg_data = NULL,
+      .description = "param with which is called method via DBus",
+      .arg_description = "<param>",
+    }, {
+      .long_name = "dest",
+      .short_name = 'd',
+      .flags = G_OPTION_FLAG_NONE,
+      .arg = G_OPTION_ARG_STRING,
+      .arg_data = NULL,
+      .description = "<dest id> to send signal/call method($TYM_ID is default)",
+      .arg_description = "<dest id>",
+    }
+  };
+
+  GOptionEntry* options_entries = (GOptionEntry*)g_malloc0_n(
+      sizeof(app_options) / sizeof(GOptionEntry) + meta_size(meta) + 1,
+      sizeof(GOptionEntry));
+  memmove(options_entries, app_options, sizeof(app_options));
+  unsigned i = sizeof(app_options) / sizeof(GOptionEntry);
+
+  for (GList* li = meta->list; li != NULL; li = li->next) {
+    MetaEntry* me = (MetaEntry*)li->data;
+    GOptionEntry* e = &options_entries[i];
+    i += 1;
+    e->long_name = me->name;
+    e->short_name = me->short_name;
+    e->flags = me->option_flag;
+    e->arg_description = me->arg_desc;
+    e->description = me->desc;
+    switch (me->type) {
+      case META_ENTRY_TYPE_STRING:
+        e->arg = G_OPTION_ARG_STRING;
+        break;
+      case META_ENTRY_TYPE_INTEGER:
+        e->arg = G_OPTION_ARG_INT;
+        break;
+      case META_ENTRY_TYPE_BOOLEAN:
+        e->arg = G_OPTION_ARG_NONE;
+        break;
+      case META_ENTRY_TYPE_NONE:;
+        break;
+    }
+  }
+  return options_entries;
+}

--- a/src/meta.c
+++ b/src/meta.c
@@ -259,7 +259,7 @@ GOptionEntry* meta_get_option_entries(Meta* meta)
       .description = "<id> to use in the new instance",
       .arg_description = "<id>",
     }, {
-      .long_name = "send",
+      .long_name = "signal",
       .short_name = 's',
       .flags = G_OPTION_FLAG_NONE,
       .arg = G_OPTION_ARG_STRING,

--- a/src/option.c
+++ b/src/option.c
@@ -8,85 +8,12 @@
  */
 
 #include "option.h"
-#include "meta.h"
+#include "app.h"
 
 
-Option* option_init(Meta* meta)
+Option* option_init()
 {
   Option* option = g_malloc0(sizeof(Option));
-
-  GOptionEntry app_options[] = {
-    {
-      .long_name = "version",
-      .short_name = 'v',
-      .flags = G_OPTION_FLAG_NONE,
-      .arg = G_OPTION_ARG_NONE,
-      .arg_data = &option->version,
-      .description = "Show version",
-      .arg_description = NULL,
-    }, {
-      .long_name = "use",
-      .short_name = 'u',
-      .flags = G_OPTION_FLAG_NONE,
-      .arg = G_OPTION_ARG_STRING,
-      .arg_data = &option->config_path,
-      .description = "<path> to config file. Set '" TYM_SYMBOL_NONE "' to start without loading config",
-      .arg_description = "<path>",
-    }, {
-      .long_name = "theme",
-      .short_name = 't',
-      .flags = G_OPTION_FLAG_NONE,
-      .arg = G_OPTION_ARG_STRING,
-      .arg_data = &option->theme_path,
-      .description = "<path> to theme file. Set '" TYM_SYMBOL_NONE "' to start without loading theme",
-      .arg_description = "<path>",
-    }, {
-      .long_name = "signal",
-      .short_name = 's',
-      .flags = G_OPTION_FLAG_NONE,
-      .arg = G_OPTION_ARG_STRING,
-      .arg_data = &option->signal,
-      .description = "Signal to send via D-Bus",
-      .arg_description = "<signal>",
-    }, {
-      .long_name = "nolua",
-      .flags = G_OPTION_FLAG_NONE,
-      .arg = G_OPTION_ARG_NONE,
-      .arg_data = &option->nolua,
-      .description = "Launch without Lua context",
-    }
-  };
-
-  GOptionEntry* options_entries = (GOptionEntry*)g_malloc0_n(
-      sizeof(app_options) / sizeof(GOptionEntry) + meta_size(meta) + 1,
-      sizeof(GOptionEntry));
-  memmove(options_entries, app_options, sizeof(app_options));
-  unsigned i = sizeof(app_options) / sizeof(GOptionEntry);
-
-  for (GList* li = meta->list; li != NULL; li = li->next) {
-    MetaEntry* me = (MetaEntry*)li->data;
-    GOptionEntry* e = &options_entries[i];
-    i += 1;
-    e->long_name = me->name;
-    e->short_name = me->short_name;
-    e->flags = me->option_flag;
-    e->arg_description = me->arg_desc;
-    e->description = me->desc;
-    switch (me->type) {
-      case META_ENTRY_TYPE_STRING:
-        e->arg = G_OPTION_ARG_STRING;
-        break;
-      case META_ENTRY_TYPE_INTEGER:
-        e->arg = G_OPTION_ARG_INT;
-        break;
-      case META_ENTRY_TYPE_BOOLEAN:
-        e->arg = G_OPTION_ARG_NONE;
-        break;
-      case META_ENTRY_TYPE_NONE:;
-        break;
-    }
-  }
-  option->entries = options_entries;
   return option;
 }
 
@@ -95,25 +22,15 @@ void option_close(Option* option)
   if (option->values) {
     g_variant_dict_unref(option->values);
   }
-  g_free(option->entries);
   g_free(option);
 }
 
-void option_register_entries(Option* option, GApplication* app)
+void option_set_values(Option* option, GVariantDict* values)
 {
-  g_application_add_main_option_entries(app, option->entries);
-}
-
-void option_load_from_cli(Option* option, GApplicationCommandLine* cli)
-{
-  GVariantDict* values = g_application_command_line_get_options_dict(cli);
-  if (option->values) {
-    g_variant_dict_unref(option->values);
-  }
   option->values = g_variant_dict_ref(values);
 }
 
-bool option_get_str_value(Option* option, const char* key, const char** value)
+bool option_get_str_value(Option* option, const char* key, char** value)
 {
   if (!option->values) {
     return false;
@@ -152,27 +69,62 @@ bool option_get_bool_value(Option* option, const char* key, bool* value)
   return has_value;
 }
 
-bool option_get_version(Option* option)
+/* bool option_get_str_value(Option* option, const char* key, const char** value) */
+/* { */
+/*   void* p = option_get(option, key); */
+/*   if (!p) { */
+/*     return false; */
+/*   } */
+/*   if (!(char**)p) { */
+/*     return false; */
+/*   } */
+/*   *value = *(char**)p; */
+/*   return true; */
+/* } */
+/*  */
+/* bool option_get_int_value(Option* option, const char* key, int* value) */
+/* { */
+/*   void* p = option_get(option, key); */
+/*   if (!p) { */
+/*     return false; */
+/*   } */
+/*   *value = *(int*)p; */
+/*   return true; */
+/* } */
+/*  */
+/* bool option_get_bool_value(Option* option, const char* key, bool* value) */
+/* { */
+/*   void* p = option_get(option, key); */
+/*   if (!p) { */
+/*     return false; */
+/*   } */
+/*   *value = *(bool*)p; */
+/*   return true; */
+/* } */
+
+char* option_get_str(Option* option, const char* key)
 {
-  return option->version;
+  char* v = NULL;
+  if (option_get_str_value(option, key, &v)) {
+    return NULL;
+  }
+  return v;
 }
 
-char* option_get_config_path(Option* option)
+int option_get_int(Option* option, const char* key)
 {
-  return option->config_path;
+  int v = 0;
+  if (option_get_int_value(option, key, &v)) {
+    return 0;
+  }
+  return v;
 }
 
-char* option_get_theme_path(Option* option)
+bool option_get_bool(Option* option, const char* key)
 {
-  return option->theme_path;
-}
-
-char* option_get_signal(Option* option)
-{
-  return option->signal;
-}
-
-bool option_get_nolua(Option* option)
-{
-  return option->nolua;
+  bool v = 0;
+  if (option_get_bool_value(option, key, &v)) {
+    return 0;
+  }
+  return v;
 }

--- a/src/tym.c
+++ b/src/tym.c
@@ -10,11 +10,18 @@
 #include "tym.h"
 
 
+
+bool local_command_line(GApplication* application,char*** arguments, int* exit_status)
+{
+  df();
+  return TRUE;
+}
+
 int main(int argc, char* argv[])
 {
   dd("start");
-  Context* context = context_init();
-  int exit_code =  context_start(context, argc, argv);
-  context_close(context);
+  app_init();
+  int exit_code = app_start(argc, argv);
+  app_close();
   return exit_code;
 }


### PR DESCRIPTION
# Interprocess communication using DBus

## Instance ID

As a new feature, each instance has unique ID. It starts from `0`.

```
$ echo $TYM_ID
0
```

You can specify it by command line option. If you start by `$ tym --id 123`, the value will be set.

```
$ echo $TYM_ID
123
```

Each instance subscribes DBus signal/method-call in object path `/me/endaaman/tym<ID>` so in the above case, the object path would be `/me/endaaman/tym123`.


## DBus signal

Only one signal: `hook` is available. This triggers Lua `'signal'` hook. For example `hook.lua` is

```lua
local tym = require('tym')

tym.set_hook('signal', function (p)
  print('Hello from DBus signal')
  print('param:', p)
end)
```

and you can start tym by

```
$ tym --id 123 -u hook.lua
```

then you can send signal like the following.

```
$ dbus-send /me/endaaman/tym123 me.endaaman.tym.hook string:'THIS IS PARAM'
```

Then you will get like

```
** Message: 12:17:21.822: [id=123]: init
** Message: 12:17:21.823: [id=123]: DBus is active on path:'/me/endaaman/tym123' interface:'me.endaaman.tym'
Hello from DBus signal
param:  THIS IS PARAM
```

Or you can send signal by `tym` command.

```
$ tym --dest 123 --send hook --param 'THIS IS PARAM'
```

And more, if you exec above command in tym whose ID is `123`,  `--dest 123` is no longer needed. The value of `$TYM_ID` is automatically used. So just only

```
$ tym --send hook --param 'THIS IS PARAM'
```

will send the signal to itself.


## DBus method call

### overview

The difference between method call and signal is whether the result is returned or not.

The new methods are above.

- `echo`
- `get_ids`
- `eval`
- `eval_file`
- `exec`
- `exec_file`

You have 2 ways to do method calling. 1st is using `dbus-send`.

```
 $ dbus-send --print-reply --type=method_call --dest=me.endaaman.tym_dev /me/endaaman/tym_dev123 me.endaaman.tym_dev.echo string:'Hello tym'
```

The output would be like

```
method return time=1645762321.811927 sender=:1.2830 -> destination=:1.2836 serial=38 reply_serial=2
   string "Hello tym"```
```

`echo` method replies exactly the same to the input.

The 2nd way is using `tym` command.

```
$ tym --dest 123 --call echo --param 'Hello tym'
('Hello tym',)
```

If the dest is the current instance, of course, it can be omitted. So just enough like `$ tym --call echo  --param 'Hello tym'`.

### method: `get_ids`

It is just to get instances ids.

```
$ tym --dest 123 --call get_ids
([0, 123],)
```


### method: `eval`

`exec` method executes Lua source code and outputs  the`return`ed value.

```
$ tym --dest 123 --call eval --param 'return "VERSION IS " .. tym.get_version()'
('VERSION IS 3.2.0',)
```

The difference between the rest `eval_file` `exec` `exec_file` is whether the output returns and whether the  output returns.
