### PR TITLE
modify selection and set/get scroll_on_output

### DIFF
--- a/include/property.h
+++ b/include/property.h
@@ -81,6 +81,9 @@ int getter_scrollback_length(Context* context, const char* key);
 void setter_scrollback_length(Context* context, const char* key, int value);
 
 // bool
+bool getter_scroll_on_output(Context* context, const char* key);
+void setter_scroll_on_output(Context* context, const char* key, bool value);
+
 bool getter_silent(Context* context, const char* key);
 void setter_silent(Context* context, const char* key, bool value);
 

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -782,6 +782,26 @@ static int builtin_get_selection(lua_State* L)
   return 1;
 }
 
+static int builtin_unselect_all(lua_State* L)
+{
+	Context* context = (Context*)lua_touserdata(L, lua_upvalueindex(1));
+	vte_terminal_unselect_all(context->layout.vte);
+	return 0;
+}
+
+static int builtin_select_all(lua_State *L) {
+	Context* context = (Context*)lua_touserdata(L, lua_upvalueindex(1));
+	vte_terminal_select_all(context->layout.vte);
+	return 0;
+}
+
+static int builtin_has_selection(lua_State *L) {
+	Context* context = (Context*)lua_touserdata(L, lua_upvalueindex(1));
+	lua_pushboolean(L, vte_terminal_get_has_selection(context->layout.vte));
+	return 1;
+}
+
+
 static int builtin_get_text(lua_State* L)
 {
   Context* context = (Context*)lua_touserdata(L, lua_upvalueindex(1));
@@ -919,6 +939,9 @@ int builtin_register_module(lua_State* L)
     { "get_cursor_position" , builtin_get_cursor_position  },
     { "get_clipboard"       , builtin_get_clipboard        },
     { "get_selection"       , builtin_get_selection        },
+    { "unselect_all"        , builtin_unselect_all         },
+    { "select_all"          , builtin_select_all           },
+    { "has_selection"       , builtin_has_selection        },
     { "get_text"            , builtin_get_text             },
     { "get_config_path"     , builtin_get_config_path      },
     { "get_theme_path"      , builtin_get_theme_path       },

--- a/src/meta.c
+++ b/src/meta.c
@@ -152,6 +152,11 @@ Meta* meta_init()
       .getter=CB(getter_scrollback_length), .setter=CB(setter_scrollback_length)
     },
     // BOOL
+	{
+		.name="scroll_on_output", .type=T_BOOL, .default_value=memdup(&v_false, sizeof(bool)),
+		.desc="Scroll down on output",
+		.getter=CB(getter_scroll_on_output), .setter=CB(setter_scroll_on_output)
+	},
     {
       .name="ignore_default_keymap", .type=T_BOOL, .default_value=memdup(&v_false, sizeof(bool)),
       .desc="Whether to use default keymap",

--- a/src/property.c
+++ b/src/property.c
@@ -426,6 +426,16 @@ void setter_scrollback_length(Context* context, const char* key, int value)
 
 
 // BOOL
+bool getter_scroll_on_output(Context* context, const char* key)
+{
+  return vte_terminal_get_scroll_on_output(context->layout.vte);
+}
+
+void setter_scroll_on_output(Context* context, const char* key, bool value)
+{
+  vte_terminal_set_scroll_on_output(context->layout.vte, value);
+}
+
 bool getter_silent(Context* context, const char* key)
 {
   return !vte_terminal_get_audible_bell(context->layout.vte);


### PR DESCRIPTION
Hello,

i needed some functions, so i added them for me.

Maybe you find them useful too.

I added the builtin functions has_selection(), select_all() and unselect_all() and the property 'scroll_on_output'.

I use these functions in my config-file:

```
tym.set_keymap('<Ctrl>c', function()
	if tym.has_selection() then
		local text = tym.get_selection()
		tym.notify(("%q"):format(text), "Copy")
		tym.copy_selection()
		tym.unselect_all()
	else
		return true
	end
end)

tym.set_keymap('<Ctrl>a', function()
	tym.select_all()
end)

tym.set_keymap('F12', function()
	local enabled = not tym.get('scroll_on_output')
	tym.notify(("enabled = %s"):format(enabled), "Scroll on output")
	tym.set('scroll_on_output', enabled)
end)
```

Btw: I love tym! Especially the use of lua as an configuration- and scripting-language is great.

Thank you,
Thomas
