### PR TITLE
URI handling

### DIFF
--- a/include/regex.h
+++ b/include/regex.h
@@ -16,6 +16,8 @@
  *     - absolute-URI       special case of URI. not distinguishable in regex.
  *     - path               not referenced from any other rules.
  *     - path-empty         to avoid highlighting meaningless URI like `foo:`.
+ *     - gen-delims         not referenced from any other rules.
+ *     - reserved           not referenced from any other rules.
  *
  * Copyright (c) 2020 endaaman, iTakeshi
  *
@@ -55,7 +57,7 @@
  * main rules
  */
 
-#define SCHEMELESS_URI  "(?:" ":" HIER_PART "(?:" "\\?" QUERY ")?" "(?:" "\\#" FRAGMENT ")?" ")"
+#define SCHEMELESS_URI  "(?:" ":" HIER_PART "(?:" "\\?" QUERY ")?" "(?:" "\\#" QUERY ")?" ")"
 
 #define HIER_PART       "(?:" "\\/\\/" AUTHORITY PATH_ABEMPTY "|" PATH_ABSOLUTE "|" PATH_ROOTLESS ")"
 
@@ -65,11 +67,11 @@
 
 #define HOST            "(?:" IP_LITERAL "|" IPV4ADDRESS "|" REG_NAME")"
 
-#define PORT            "(?:" DIGIT ")*"
+#define PORT            "(?:" DIGIT ")*+"
 
 #define IP_LITERAL      "(?:" "\\[" "(?:" IPV6ADDRESS "|" IPVFUTURE ")" "\\]" ")"
 
-#define IPVFUTURE       "(?:" "v" "(?:" HEXDIG ")++" "\\." "(?:" UNRESERVED "|" SUB_DELIMS "|" ":" ")++" ")"
+#define IPVFUTURE       "(?:" "v" HEXDIG "++" "\\." "(?:" UNRESERVED "|" SUB_DELIMS "|" ":" ")++" ")"
 
 #define IPV6ADDRESS     "(?:"                                            "(?:" H16 ":" "){6}" LS32 \
                           "|"                                       "::" "(?:" H16 ":" "){5}" LS32 \
@@ -94,7 +96,7 @@
 
 #define PATH_ABEMPTY    "(?:" "\\/" SEGMENT ")*+"
 
-#define PATH_ABSOLUTE   "(?:" "\\/" "(?:" SEGMENT_NZ PATH_ABEMPTY ")?" ")"
+#define PATH_ABSOLUTE   "(?:" "\\/" PATH_ROOTLESS "?" ")"
 
 #define PATH_ROOTLESS   "(?:" SEGMENT_NZ PATH_ABEMPTY ")"
 
@@ -106,15 +108,9 @@
 
 #define QUERY           "(?:" PCHAR "|" "\\/" "|" "\\?" ")*+"
 
-#define FRAGMENT        "(?:" PCHAR "|" "\\/" "|" "\\?" ")*+"
-
 #define PCT_ENCODED     "(?:" "%" HEXDIG HEXDIG ")"
 
 #define UNRESERVED      "(?:" ALPHA "|" DIGIT "|" "[\\-\\._~]" ")"
-
-#define RESERVED        "(?:" GEN_DELIMS "|" SUB_DELIMS ")"
-
-#define GEN_DELIMS      "(?:" "[:\\/\\?\\#\\[\\]@]" ")"
 
 #define SUB_DELIMS      "(?:" "[!\\$&'\\(\\)\\*\\+,;=]" ")"
 

--- a/include/regex.h
+++ b/include/regex.h
@@ -7,6 +7,8 @@
  * NOTE:
  *   * URI is repleced by SCHEMELESS_URI, because the entire URI regex is dynamically constructed
  *     using an user-configured list of target schemes. SCHEME is used to validate the list.
+ *   * SUB_DELIMS does not contain "(" and ")", and subsequently USERINFO, IPVFUTURE, and REG_NAME do not allow these
+ *     characters. SEGMENT and QUERY rules have special PAREN rules that matches only paired "(" and ")".
  *   * Also, the following definitions are omitted:
  *     - URI-reference      only used in relative URIs.
  *     - relative-ref       (as above)
@@ -100,19 +102,23 @@
 
 #define PATH_ROOTLESS   "(?:" SEGMENT_NZ PATH_ABEMPTY ")"
 
-#define SEGMENT         "(?:" PCHAR ")*+"
+#define SEGMENT         "(?:" PCHAR "|" PAREN ")*+"
 
-#define SEGMENT_NZ      "(?:" PCHAR ")++"
+#define SEGMENT_NZ      "(?:" PCHAR "|" PAREN ")++"
 
-#define PCHAR           "(?:" UNRESERVED "|" PCT_ENCODED "|" SUB_DELIMS "|" ":" "|" "@" ")"
+#define PCHAR           "(?:" UNRESERVED "|" PCT_ENCODED "|" SUB_DELIMS "|" "[:@]" ")"
 
-#define QUERY           "(?:" PCHAR "|" "\\/" "|" "\\?" ")*+"
+#define PAREN           "(?:" "\\(" PCHAR "*+" "\\)" ")"
+
+#define QUERY           "(?:" PCHAR "|" "[\\/\\?]" "|" QUERY_PAREN ")*+"
+
+#define QUERY_PAREN     "(?:" "\\(" "(?:" PCHAR "|" "[\\/\\?]" ")*+" "\\)" ")"
 
 #define PCT_ENCODED     "(?:" "%" HEXDIG HEXDIG ")"
 
 #define UNRESERVED      "(?:" ALPHA "|" DIGIT "|" "[\\-\\._~]" ")"
 
-#define SUB_DELIMS      "(?:" "[!\\$&'\\(\\)\\*\\+,;=]" ")"
+#define SUB_DELIMS      "(?:" "[!\\$&'\\*\\+,;=]" ")"
 
 
 #endif

--- a/src/app.c
+++ b/src/app.c
@@ -302,6 +302,9 @@ static bool on_vte_click(VteTerminal* vte, GdkEventButton* event, void* user_dat
     return false;
   }
   if (uri) {
+    for (int i = strlen(uri) - 1; uri[i] == '.' || uri[i] == ','; i--) {
+      uri[i] = '\0';
+    }
     context_launch_uri(context, uri);
     return true;
   }

--- a/src/regex_test.c
+++ b/src/regex_test.c
@@ -124,6 +124,7 @@ void test_regex()
 
   // cases are cited from RFC3987 and RFC6068
   printf("Integrated tests\n");
+  g_assert(check_match(0 , URI , "http://localhost:3000/index.html"                                         , "http://localhost:3000/index.html"                                       , 0));
   g_assert(check_match(0 , URI , "http://www.example.org/D%C3%BCrst"                                        , "http://www.example.org/D%C3%BCrst"                                      , 0));
   g_assert(check_match(0 , URI , "http://www.example.org/D&#xFC;rst"                                        , "http://www.example.org/D&#xFC;rst"                                      , 0));
   g_assert(check_match(0 , URI , "http://www.example.org/D%FCrst"                                           , "http://www.example.org/D%FCrst"                                         , 0));

--- a/src/regex_test.c
+++ b/src/regex_test.c
@@ -167,8 +167,5 @@ void test_regex()
   // NOT match
   g_assert(check_match(0 , URI , "foo:" , NULL , 1));  // only scheme-like part
 
-  // TODO https://github.com/endaaman/tym/issues/46
-  // assert(check_match(0, URI, "link to https://example.com." , "https://example.com" , 0));
-
   printf("regex tests complete!\n");
 }

--- a/src/regex_test.c
+++ b/src/regex_test.c
@@ -102,10 +102,10 @@ void test_regex()
   g_assert(check_match(1, SCHEME , "0foo"    , NULL , 1)); // disallow non-alphabet character at the beginning
 
   printf("Testing USERINFO\n");
-  g_assert(check_match(1, USERINFO , "foo.bar-baz"          , NULL , 0));
-  g_assert(check_match(1, USERINFO , "user:pass!$&'()*+,;=" , NULL , 0));
-  g_assert(check_match(1, USERINFO , "user@"                , NULL , 1)); // disallow `@`
-  g_assert(check_match(1, USERINFO , "user:pass@"           , NULL , 1)); // disallow `@`
+  g_assert(check_match(1, USERINFO , "foo.bar-baz"        , NULL , 0));
+  g_assert(check_match(1, USERINFO , "user:pass!$&'*+,;=" , NULL , 0));
+  g_assert(check_match(1, USERINFO , "user@"              , NULL , 1)); // disallow `@`
+  g_assert(check_match(1, USERINFO , "user:pass@"         , NULL , 1)); // disallow `@`
 
   printf("Testing HOST\n");
   g_assert(check_match(1 , HOST , "localhost"                 , NULL , 0));
@@ -155,15 +155,20 @@ void test_regex()
   g_assert(check_match(0 , URI , "<mailto:user@%E7%B4%8D%E8%B1%86.example.org?subject=Test&body=NATTO>"     , "mailto:user@%E7%B4%8D%E8%B1%86.example.org?subject=Test&body=NATTO"     , 0));
   g_assert(check_match(0 , URI , "file:///"                                                                 , "file:///"                                                               , 0));
   g_assert(check_match(0 , URI , "file:///home/user/example.txt"                                            , "file:///home/user/example.txt"                                          , 0));
+  g_assert(check_match(0 , URI, "[link](https://example.com)"                                               , "https://example.com"                                                    , 0));
+  g_assert(check_match(0 , URI, "[link](https://example.com/path)"                                          , "https://example.com/path"                                               , 0));
+  g_assert(check_match(0 , URI, "[link](https://example.com/path?query)"                                    , "https://example.com/path?query"                                         , 0));
+  g_assert(check_match(0 , URI, "[link](https://example.com/path?query#fragment)"                           , "https://example.com/path?query#fragment"                                , 0));
+  g_assert(check_match(0 , URI, "[link](https://example.com/p(at)h?q(uer)y#fr(ag)ment)"                     , "https://example.com/p(at)h?q(uer)y#fr(ag)ment"                          , 0));
+  g_assert(check_match(0 , URI, "[link](https://example.com/pat)h?q(uer)y#fr(ag)ment)"                      , "https://example.com/pat"                                                , 0));
+  g_assert(check_match(0 , URI, "[link](https://example.com/p(at)h?quer)y#fr(ag)ment)"                      , "https://example.com/p(at)h?quer"                                        , 0));
+  g_assert(check_match(0 , URI, "[link](https://example.com/p(at)h?q(uer)y#frag)ment)"                      , "https://example.com/p(at)h?q(uer)y#frag"                                , 0));
 
   // NOT match
-  assert(check_match(0 , URI , "foo:" , NULL , 1));  // only scheme-like part
+  g_assert(check_match(0 , URI , "foo:" , NULL , 1));  // only scheme-like part
 
   // TODO https://github.com/endaaman/tym/issues/46
-  //
-  // assert(check_match(0, URI, "[link](https://example.com)"  , "https://example.com" , 0));
   // assert(check_match(0, URI, "link to https://example.com." , "https://example.com" , 0));
 
   printf("regex tests complete!\n");
 }
-


### PR DESCRIPTION
Fixes #46

### Parentheses in URI
- `(` and `)` in a URI should be paired, otherwise they are removed from the match. This fixes the markdown link problem like `[link](https://example.com)` --- which is previously matched as `https://example.com)` but now it's correctly matched as `https://example.com`. 
- On the other hand, matched parentheses in a URI can be detected, like `https://en.wikipedia.org/wiki/WWW_(disambiguation)`.
- NOTE: This regex cannot detect nested parentheses. IMO it's acceptable for daily normal usecases.

### Trailing periods/commas in URI
- In a sentence like `Refer to the doc: https://doc.example.com/index.html.`, the regex detect the URI as `https://doc.example.com/index.html.` with the trailing period, leading us to the 404 page.
- I couldn't find a sophisticated way to detect/remove such trailing periods (note: lookaround is not what we want here) thus I wrote a small snippet to remove periods and commas in C code.