### PR TITLE
Daemon process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ tym.1
 tym
 tym-test
 include/common.h
+tym-daemon.service
 /config.*
 /app-config.*
 tym-*.tar.gz

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,3 +3,6 @@ man_MANS = tym.1
 desktopdir = $(datadir)/applications
 EXTRA_DIST = $(man_MANS)
 dist_desktop_DATA = tym.desktop
+
+systemunitdir = $(sysconfdir)/systemd/user/
+dist_systemunit_DATA = tym-daemon.service

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,5 +4,5 @@ desktopdir = $(datadir)/applications
 EXTRA_DIST = $(man_MANS)
 dist_desktop_DATA = tym.desktop
 
-systemunitdir = $(sysconfdir)/systemd/user/
+systemunitdir = $(libdir)/systemd/user/
 dist_systemunit_DATA = tym-daemon.service

--- a/README.md
+++ b/README.md
@@ -439,6 +439,30 @@ Calls D-Bus method of the current instance (determined by `$TYM_ID` environment 
 $ tym --call eval --param 'return 1 + 2'
 ```
 
+### `--daemon`
+
+This makes tym a daemon process, which has no window or application context.
+
+```
+$ tym --daemon
+```
+
+When the primary instance exists, the secondary execution will be united into the primary and it will be a bit faster because it has less cost to initialize GTK application footprint. The daemon process makes first execution like as secondary.
+
+This execution is wrapped as systemd-unit.
+
+```
+$ systemctl --user start tym-daemon.service
+```
+
+However, this will also failed in your working tym instance. To start the daemon process, we need to stop all tym instances including the terminal just you are working on!
+
+So the following may help you.
+
+```
+$ nohup sh -c 'killall tym; sleep 1; systemctl --user start tym-daemon.service; tym' >/dev/null 2>&1 &
+```
+
 ### `--<config option>`
 
 You can set config value via command line option.

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ AC_CONFIG_FILES([
   src/Makefile
   include/Makefile
   include/common.h
+  tym-daemon.service
   tym.1
 ])
 

--- a/src/app.c
+++ b/src/app.c
@@ -122,6 +122,16 @@ int app_start(Option* option, int argc, char **argv)
   GError* error = NULL;
   g_application_register(app->gapp, NULL, &error);
 
+  if (option_get_bool(option, "daemon")) {
+    if (g_application_get_is_remote(app->gapp)) {
+      /* If there is a normal primary instance, --daemon flag would make it "zombie" */
+      /* So daemonization should be allowed only when the instanciation is the primary */
+      g_warning("There is any tym instance. So could not start as daemon process.");
+      g_application_run(app->gapp, argc, argv);
+      return 1;
+    }
+  }
+
   char* dest_path = _get_dest_path_from_option(option);
   char* signal_name = option_get_str(option, "signal");
   char* method_name = option_get_str(option, "call");
@@ -129,6 +139,7 @@ int app_start(Option* option, int argc, char **argv)
   if (signal_name || method_name) {
     int code = _perform_signal(dest_path, signal_name, method_name, param);
     g_free(dest_path);
+    g_application_run(app->gapp, argc, argv);
     return code;
   }
 
@@ -535,13 +546,20 @@ int on_command_line(GApplication* gapp, GApplicationCommandLine* cli, void* user
   if (option_get_bool(option, "daemon")) {
     GtkWindow* window = gtk_application_get_active_window(GTK_APPLICATION(gapp));
     if (window) {
-      g_warning("There is any tym instance, so could not start as daemon process.");
+      g_warning("Blocked another instance from trying to start as daemon process.");
       return 1;
     }
 
-    /* only creates window, never shows it. */
-    window = GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(app->gapp)));
+    /* Only creates a window, never shows it. */
+    window = GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(gapp)));
+    UNUSED(window);
     g_message("Starting as daemon process.");
+    return 0;
+  }
+
+  if (option_get_str(option, "signal") || option_get_str(option, "call")) {
+    /* Do nothing */
+    dd("D-Bus signal/method call was performed on a remote process.");
     return 0;
   }
 

--- a/src/app.c
+++ b/src/app.c
@@ -132,8 +132,6 @@ int app_start(Option* option, int argc, char **argv)
     return code;
   }
 
-  /* g_application_add_main_option_entries(app->gapp, entries); */
-
   g_signal_connect(app->gapp, "handle-local-options", G_CALLBACK(on_local_options), option);
   g_signal_connect(app->gapp, "command-line", G_CALLBACK(on_command_line), NULL);
   return g_application_run(app->gapp, argc, argv);
@@ -533,6 +531,12 @@ int on_command_line(GApplication* gapp, GApplicationCommandLine* cli, void* user
   if (!option_parse(option, argc, argv)){
     return 1;
   };
+
+  if (option_get_bool(option, "daemon")) {
+    g_message("Starting as daemon process.");
+    gtk_main(); // Start empty main loop
+    return 0;
+  }
 
   Context* context = app_spawn_context(option);
   if (!context) {

--- a/src/app.c
+++ b/src/app.c
@@ -533,8 +533,15 @@ int on_command_line(GApplication* gapp, GApplicationCommandLine* cli, void* user
   };
 
   if (option_get_bool(option, "daemon")) {
+    GtkWindow* window = gtk_application_get_active_window(GTK_APPLICATION(gapp));
+    if (window) {
+      g_warning("There is any tym instance, so could not start as daemon process.");
+      return 1;
+    }
+
+    /* only creates window, never shows it. */
+    window = GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(app->gapp)));
     g_message("Starting as daemon process.");
-    gtk_main(); // Start empty main loop
     return 0;
   }
 

--- a/src/meta.c
+++ b/src/meta.c
@@ -270,6 +270,13 @@ GOptionEntry* meta_get_option_entries(Meta* meta)
       .description = "Show version",
       .arg_description = NULL,
     }, {
+      .long_name = "daemon",
+      .short_name = 'v',
+      .arg = G_OPTION_ARG_NONE,
+      .arg_data = new_empty_bool(),
+      .description = "Launch as daemon process",
+      .arg_description = NULL,
+    }, {
       .long_name = "use",
       .short_name = 'u',
       .arg = G_OPTION_ARG_STRING,

--- a/tym-daemon.service
+++ b/tym-daemon.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=tym daemon
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/tym --daemon
+
+[Install]
+WantedBy=default.target

--- a/tym-daemon.service.in
+++ b/tym-daemon.service.in
@@ -3,7 +3,7 @@ Description=tym daemon
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/tym --daemon
+ExecStart=@prefix@/bin/tym --daemon
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Adding `--daemon`

- The daemon process has no windows.
- When the daemon process exist, new executions will exit imediatelly and the instance will be created in the daemon process.
- `--isolated` process will not be united into the daemon process (it will has always an unique process by an instance).

## TODOs

- [x] PoC implementation
- [x] add systemd unit
- [x] update README