### PR TITLE
Detect and set current working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,15 @@ So the following may help you.
 $ nohup sh -c 'killall tym; sleep 1; systemctl --user start tym-daemon.service; tym' >/dev/null 2>&1 &
 ```
 
+
+### `--cwd=<path>`
+
+This sets the terminal's working directory. `<path>` must be an absolute path. If unspecified `tym` will use the current working directory of the terminal invocation.
+
+```console
+$ tym --cwd=/home/user/projects
+```
+
 ### `--<config option>`
 
 You can set config value via command line option.

--- a/src/app.c
+++ b/src/app.c
@@ -438,6 +438,13 @@ void on_dbus_call_method(
 
 int on_local_options(GApplication* gapp, GVariantDict* values, void* user_data)
 {
+  Option* option = (Option*)(user_data);
+  const char* cwd = option_get_str(option, "cwd");
+  if (cwd != NULL && !g_path_is_absolute(cwd)) {
+    g_warning("cwd must be an absolute path");
+    return 1;
+  }
+
   df();
   return -1;
 }
@@ -630,7 +637,10 @@ int on_command_line(GApplication* gapp, GApplicationCommandLine* cli, void* user
   shell_env = g_environ_setenv(shell_env, "TYM_ID", id_str, true);
   g_free(id_str);
 
-  char* cwd = g_application_command_line_get_cwd(cli);
+  char* cwd = option_get_str(option, "cwd");
+  if (cwd == NULL) {
+    cwd = g_application_command_line_get_cwd(cli);
+  }
 
 #ifdef TYM_USE_VTE_SPAWN_ASYNC
   vte_terminal_spawn_async(

--- a/src/app.c
+++ b/src/app.c
@@ -630,11 +630,13 @@ int on_command_line(GApplication* gapp, GApplicationCommandLine* cli, void* user
   shell_env = g_environ_setenv(shell_env, "TYM_ID", id_str, true);
   g_free(id_str);
 
+  char* cwd = g_application_command_line_get_cwd(cli);
+
 #ifdef TYM_USE_VTE_SPAWN_ASYNC
   vte_terminal_spawn_async(
     vte,                 // terminal
     VTE_PTY_DEFAULT,     // pty flag
-    NULL,                // working directory
+    cwd,                 // working directory
     shell_argv,          // argv
     shell_env,           // envv
     G_SPAWN_SEARCH_PATH, // spawn_flags
@@ -651,7 +653,7 @@ int on_command_line(GApplication* gapp, GApplicationCommandLine* cli, void* user
   vte_terminal_spawn_sync(
     vte,
     VTE_PTY_DEFAULT,
-    NULL,
+    cwd,
     shell_argv,
     shell_env,
     G_SPAWN_SEARCH_PATH,

--- a/src/meta.c
+++ b/src/meta.c
@@ -330,6 +330,12 @@ GOptionEntry* meta_get_option_entries(Meta* meta)
       .arg_data = new_empty_bool(),
       .description = "Start as an isolated instance",
       .arg_description = NULL,
+    }, {
+      .long_name = "cwd",
+      .arg = G_OPTION_ARG_STRING,
+      .arg_data = new_empty_str(),
+      .description = "Set the terminal's working directory. Must be an absolute path.",
+      .arg_description = "<path>",
     }
   };
 

--- a/tym.1.in
+++ b/tym.1.in
@@ -18,6 +18,9 @@ Use <PATH> instead of default config file.
 .IP "\fB\-t\fR, \fB\-\-theme\fR=\fI<PATH>\fR"
 Use <PATH> instead of default theme file.
 
+.IP "\fB\-\-cwd\fR=\fI<PATH>\fR"
+Use <PATH> as the terminal's working directory. Must be an absolute path.
+
 .IP "\fB\-\-\fR\fI<OPTION>\fR=\fI<VALUE>\fR"
 Replace <OPTION> config option, where \fI<OPTION>\fR is a config option and
 \fI<VALUE>\fR is a value of its option.


### PR DESCRIPTION
This adds 2 changes:

1. Instead of defaulting to the daemon's working directory, All clients that are spawned will use the working directory of the command line invocation.
2. Add a `--working-directory` option to override the working directory.

This might be considered a breaking change since it alters the default behavior of newly spawned clients.